### PR TITLE
Address plugin ordering issues

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,3 @@ include setup.py
 include tox.ini
 include LICENSE
 include test_reqs.py
-graft doc
-graft test_reqs.py

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,27 @@ option::
         mycustomrequirementsfile.txt
         someotherfilename.ext
 
+Running ``pytest-reqs`` before any other tests
+----------------------------------------------
+
+Currently there is no way to define the order of pytest plugins (see
+`pytest-dev/pytest#935 <https://github.com/pytest-dev/pytest/issues/935>`__)
+
+This means that if you don't use any other plugins, ``pytest-reqs`` will run
+it's tests last. If you do use other plugins, there is no way to guarantee when
+the ``pytest-reqs`` tests will be run.
+
+If you absolutely need to run ``pytest-reqs`` before any other tests and
+plugins, instead of using the ``--reqs`` flag, you can define a
+``tests/conftest.py`` file as follows:
+
+.. code-block:: python
+
+    from pytest_reqs import check_requirements
+
+    def pytest_collection_modifyitems(config, session, items):
+        check_requirements(config, session, items)
+
 Running requirements checks and no other tests
 ----------------------------------------------
 

--- a/pytest_reqs.py
+++ b/pytest_reqs.py
@@ -41,18 +41,22 @@ def pytest_sessionstart(session):
 
 def pytest_collection_modifyitems(config, session, items):
     if config.option.reqs:
-        patterns = config.patterns or DEFAULT_PATTERNS
-        filenames = set(chain.from_iterable(map(glob, patterns)))
+        check_requirements(config, session, items)
 
-        installed_distributions = dict(
-            (d.project_name.lower(), d)
-            for d in get_installed_distributions()
-        )
 
-        items.extend(
-            ReqsItem(filename, installed_distributions, config, session)
-            for filename in filenames
-        )
+def check_requirements(config, session, items):
+    patterns = config.patterns or DEFAULT_PATTERNS
+    filenames = set(chain.from_iterable(map(glob, patterns)))
+
+    installed_distributions = dict(
+        (d.project_name.lower(), d)
+        for d in get_installed_distributions()
+    )
+
+    items.extend(
+        ReqsItem(filename, installed_distributions, config, session)
+        for filename in filenames
+    )
 
 
 class PipOption:


### PR DESCRIPTION
This PR does a little refactoring to better address the somewhat un-addressable issue of when the `pytest-reqs` tests are run in relation to other plugins and regular tests.

Closes #9. 