### PR TITLE
Dynamic configuration

### DIFF
--- a/pytest_reqs.py
+++ b/pytest_reqs.py
@@ -1,3 +1,4 @@
+from distutils.util import strtobool
 from glob import glob
 from itertools import chain
 
@@ -35,8 +36,11 @@ def pytest_addoption(parser):
 
 def pytest_sessionstart(session):
     config = session.config
-    config.ignore_local = config.getini("reqsignorelocal").lower() == 'true'
-    config.patterns = config.getini("reqsfilenamepatterns")
+    if not hasattr(config, "ignore_local"):
+        ignore_local = config.getini("reqsignorelocal") or "no"
+        config.ignore_local = strtobool(ignore_local)
+    if not hasattr(config, "patterns"):
+        config.patterns = config.getini("reqsfilenamepatterns")
 
 
 def pytest_collection_modifyitems(config, session, items):

--- a/test_reqs.py
+++ b/test_reqs.py
@@ -142,3 +142,22 @@ def test_override_filenamepatterns(testdir, monkeypatch):
 
     result = testdir.runpytest("--reqs")
     assert 'passed' in result.stdout.str()
+
+
+def test_override_filenamepatterns_using_dynamic_config(testdir, monkeypatch):
+    testdir.makefile('.txt', a='foo')
+    testdir.makefile('.txt', b='bar')
+    testdir.makeconftest("""
+    def pytest_configure(config):
+        config.patterns = ['a.txt', 'b.txt']
+    """)
+    monkeypatch.setattr(
+        'pytest_reqs.get_installed_distributions',
+        lambda: [
+            stub(project_name='bar', version='1.0'),
+            stub(project_name='foo', version='1.0'),
+        ],
+    )
+
+    result = testdir.runpytest("--reqs")
+    assert 'passed' in result.stdout.str()

--- a/test_reqs.py
+++ b/test_reqs.py
@@ -109,6 +109,18 @@ def test_local_requirement_ignored(testdir, monkeypatch):
     assert 'passed' in result.stdout.str()
 
 
+def test_local_requirement_ignored_using_dynamic_config(testdir, monkeypatch):
+    testdir.makefile('.txt', requirements='-e ../foo')
+    testdir.makeconftest("""
+    def pytest_configure(config):
+        config.ignore_local = True
+    """)
+    monkeypatch.setattr('pytest_reqs.get_installed_distributions', lambda: [])
+
+    result = testdir.runpytest("--reqs")
+    assert 'passed' in result.stdout.str()
+
+
 def test_non_lowered_requirement(mock_dist, testdir, monkeypatch):
     testdir.makefile('.txt', requirements='Foo')
     monkeypatch.setattr(


### PR DESCRIPTION
Add a dynamic configuration ability, that allows setting filenamepatterns or reqsignorelocal properties using pytest hooks.
Example of usage:
```python
def pytest_configure(config):  # find reqs relative to root dir
    config.patterns = [config.rootdir.strpath + config.rootdir.sep + 'req*.txt']
```