### PR TITLE
Declare dependency on pip<10 and test pip 9.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
         url='https://github.com/di/pytest-reqs',
         py_modules=['pytest_reqs'],
         entry_points={'pytest11': ['reqs = pytest_reqs']},
-        install_requires=['pytest>=2.4.2', 'packaging>=17.1'],
+        install_requires=['pip<10', 'pytest>=2.4.2', 'packaging>=17.1'],
         tests_require=['pytest>=2.4.2', 'pretend'],
         classifiers=[
             'Framework :: Pytest',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist=py27-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},py27-pytesttrunk,py-xdist,py34,py35,py36-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},pypypy
+envlist=py27-pip{903,902,901,900,812,811,810,803,802,801,800,712,711,710},py27-pytesttrunk,py-xdist,py34,py35,py36-pip{903,902,901,900,812,811,810,803,802,801,800,712,711,710},pypypy
 
 [testenv]
 deps=
     -rrequirements/test.txt
+    pip903: pip==9.0.3
     pip902: pip==9.0.2
     pip901: pip==9.0.1
     pip900: pip==9.0.0


### PR DESCRIPTION
Fixes https://github.com/di/pytest-reqs/issues/17