### PR TITLE
Use tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ python:
   - "pypy"
 
 install:
-  - pip install tox
-  - export TOX_ENV=`tox --listenvs | grep "py${TRAVIS_PYTHON_VERSION/./}" | tr '\n' ','`
+  - pip install tox-travis
 
-script: tox -e $TOX_ENV
+script: tox
 
 before_cache:
   - rm -rf $HOME/.cache/pip/log

--- a/pytest_reqs.py
+++ b/pytest_reqs.py
@@ -9,8 +9,8 @@ from sys import executable
 from warnings import warn
 
 import packaging.version
-import pytest
 from pkg_resources import get_distribution
+import pytest
 
 max_version = packaging.version.parse('9.0.2')
 pip_version = packaging.version.parse(get_distribution('pip').version)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},py27-pytesttrunk,py-xdist,py34,py35,py36-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},pypy
+envlist=py27-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},py27-pytesttrunk,py-xdist,py34,py35,py36-flake8,py36-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},pypy
 
 [testenv]
 deps=
@@ -21,9 +21,10 @@ deps=
 commands=
     py.test {posargs}
 
-[testenv:py36]
+[testenv:py36-flake8]
+deps=
+    -rrequirements/test.txt
 commands=
-    py.test {posargs}
     flake8
 
 [testenv:py-xdist]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},py27-pytesttrunk,py-xdist,py34,py35,py36-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},pypypy
+envlist=py27-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},py27-pytesttrunk,py-xdist,py34,py35,py36-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},pypy
 
 [testenv]
 deps=
@@ -33,9 +33,6 @@ deps=
     pytest-xdist
 commands=
     py.test -n3 {posargs}
-
-[testenv:pypypy]
-basepython=pypy
 
 [pytest]
 addopts=--reqs

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},py27-pytesttrunk,py-xdist,py34,py35,py36-flake8,py36-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},pypy
+envlist=py27-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},py-xdist,py34-pip902,py35-pip902,py36-flake8,py36-pip{902,901,900,812,811,810,803,802,801,800,712,711,710},pypy-pip902
 
 [testenv]
 deps=
@@ -31,6 +31,7 @@ commands=
 basepython=python
 deps=
     -rrequirements/test.txt
+    pip==9.0.2
     pytest-xdist
 commands=
     py.test -n3 {posargs}


### PR DESCRIPTION
Works around https://github.com/di/pytest-reqs/issues/17 to get the CI green again.

https://github.com/di/pytest-reqs/pull/18 is a better option, IMO.

If https://github.com/di/pytest-reqs/pull/18 is merged, this PR should be adjusted; at least  https://github.com/di/pytest-reqs/commit/5b419248b376336537196b482be170438e343cb9 should be revised to not specify upper pip version in tox.ini, which helps test that the `install_requires` is working correctly.