### PR TITLE
setup.py: List pip as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
         url='https://github.com/di/pytest-reqs',
         py_modules=['pytest_reqs'],
         entry_points={'pytest11': ['reqs = pytest_reqs']},
-        install_requires=['pytest>=2.4.2', 'packaging>=17.1'],
+        install_requires=['pip', 'pytest>=2.4.2', 'packaging>=17.1'],
         tests_require=['pytest>=2.4.2', 'pretend'],
         classifiers=[
             'Framework :: Pytest',


### PR DESCRIPTION
This is needed for especially Python 2.7 before pip was packaged
by default with the standard library via `ensurepip`.