### PR TITLE
Load requirements as a file object

### DIFF
--- a/pytest_reqs.py
+++ b/pytest_reqs.py
@@ -1,7 +1,5 @@
 
 from distutils.util import strtobool
-from glob import glob
-from itertools import chain
 from json import loads
 from os import devnull
 from subprocess import check_output
@@ -28,6 +26,7 @@ __version__ = '0.0.4'
 DEFAULT_PATTERNS = [
     'req*.txt', 'req*.pip', 'requirements/*.txt', 'requirements/*.pip'
 ]
+_installed_requirements = None
 
 
 def pytest_addoption(parser):
@@ -61,28 +60,28 @@ def pytest_sessionstart(session):
         config.patterns = config.getini('reqsfilenamepatterns')
 
 
-def pytest_collection_modifyitems(config, session, items):
-    if config.option.reqs:
-        check_requirements(config, session, items)
-    if config.option.reqs_outdated:
-        check_outdated_requirements(config, session, items)
+def pytest_collect_file(parent, path):
+    config = parent.config
+    if _is_requirements(config, path):
+        return ReqsFile(path, parent)
 
 
-def get_reqs_filenames(config):
-    patterns = config.patterns or DEFAULT_PATTERNS
-    return set(chain.from_iterable(map(glob, patterns)))
+def _is_requirements(config, path):
+    globs = config.patterns or DEFAULT_PATTERNS
+    for glob in globs:
+        if path.check(fnmatch=glob):
+            return True
+    return False
 
 
-def check_requirements(config, session, items):
-    installed_distributions = pip_api.installed_distributions()
-
-    items.extend(
-        ReqsItem(filename, installed_distributions, config, session)
-        for filename in get_reqs_filenames(config)
-    )
+def get_installed_distributions():
+    global _installed_requirements
+    if not _installed_requirements:
+        _installed_distributions = pip_api.installed_distributions()
+    return _installed_distributions
 
 
-def check_outdated_requirements(config, session, items):
+def get_outdated_requirements():
     local_pip_version = packaging.version.parse(
         get_distribution('pip').version
     )
@@ -95,10 +94,7 @@ def check_outdated_requirements(config, session, items):
                 stderr=DEVNULL
             ))
 
-            items.extend(
-                OutdatedReqsItem(filename, pip_outdated_dists, config, session)
-                for filename in get_reqs_filenames(config)
-            )
+            return pip_outdated_dists
 
 
 class PipOption:
@@ -110,16 +106,29 @@ class ReqsError(Exception):
     """ indicates an error during requirements checks. """
 
 
-class ReqsItem(pytest.Item, pytest.File):
+class ReqsBase(object):
 
-    def __init__(self, filename, installed_distributions, config, session):
-        super(ReqsItem, self).__init__(
-            filename, config=config, session=session
+    def repr_failure(self, excinfo):
+        if excinfo.errisinstance(ReqsError):
+            return excinfo.value.args[0]
+        return super(ReqsBase, self).repr_failure(excinfo)
+
+    def reportinfo(self):
+        return (self.fspath, -1, 'requirements-check')
+
+
+class ReqsFile(ReqsBase, pytest.File):
+
+    def __init__(self, filename, parent, config=None, session=None,
+                 nodeid=None, installed_distributions=None):
+        super(ReqsFile, self).__init__(
+            filename, parent, config=config, session=session
         )
-        self.add_marker('reqs')
-        self.filename = filename
+        self.filename = str(filename)
+        if not installed_distributions:
+            installed_distributions = get_installed_distributions()
         self.installed_distributions = installed_distributions
-        self.config = config
+        self.pip_outdated_dists = None
 
     def get_requirements(self):
         try:
@@ -132,50 +141,59 @@ class ReqsItem(pytest.Item, pytest.File):
                 self.filename,
             ))
 
-    def runtest(self):
+    def collect(self):
+        if self.config.option.reqs_outdated:
+            self.pip_outdated_dists = get_outdated_requirements()
+
         for name, req in self.get_requirements().items():
-            try:
-                installed_distribution = self.installed_distributions[name]
-            except KeyError:
-                raise ReqsError(
-                    'Distribution "%s" is not installed' % (name)
-                )
-            if not req.specifier.contains(installed_distribution.version):
-                raise ReqsError(
-                    'Distribution "%s" requires %s but %s is installed' % (
-                        installed_distribution.project_name,
-                        req,
-                        installed_distribution.version,
-                    ))
+            if self.config.option.reqs:
+                yield ReqsItem(name, self, req)
+            if self.config.option.reqs_outdated:
+                yield OutdatedReqsItem(name, self, req)
 
-    def repr_failure(self, excinfo):
-        if excinfo.errisinstance(ReqsError):
-            return excinfo.value.args[0]
-        return super(ReqsItem, self).repr_failure(excinfo)
 
-    def reportinfo(self):
-        return (self.fspath, -1, 'requirements-check')
+class ReqsItem(ReqsBase, pytest.Item):
+
+    def __init__(self, name, parent, requirement):
+        super(ReqsItem, self).__init__(name, parent)
+        self.add_marker('reqs')
+        self.requirement = requirement
+        self.installed_distributions = parent.installed_distributions
+
+    def runtest(self):
+        name = self.name
+        req = self.requirement
+        try:
+            installed_distribution = self.installed_distributions[name]
+        except KeyError:
+            raise ReqsError(
+                'Distribution "%s" is not installed' % (name)
+            )
+        if not req.specifier.contains(installed_distribution.version):
+            raise ReqsError(
+                'Distribution "%s" requires %s but %s is installed' % (
+                    installed_distribution.project_name,
+                    req,
+                    installed_distribution.version,
+                ))
 
 
 class OutdatedReqsItem(ReqsItem):
-    def __init__(self, filename, pip_outdated_dists, config, session):
-        super(ReqsItem, self).__init__(
-            filename, config=config, session=session
-        )
+
+    def __init__(self, name, parent, requirement):
+        super(OutdatedReqsItem, self).__init__(name, parent, requirement)
         self.add_marker('reqs-outdated')
-        self.filename = filename
-        self.pip_outdated_dists = pip_outdated_dists
-        self.config = config
 
     def runtest(self):
-        for name, req in self.get_requirements().items():
-            for dist in self.pip_outdated_dists:
-                if name == dist['name']:
-                    raise ReqsError(
-                        'Distribution "%s" is outdated (from %s), '
-                        'latest version is %s==%s' % (
-                            name,
-                            req.comes_from,
-                            name,
-                            dist['latest_version']
-                        ))
+        name = self.name
+        req = self.requirement
+        for dist in self.parent.pip_outdated_dists:
+            if name == dist['name']:
+                raise ReqsError(
+                    'Distribution "%s" is outdated (from %s), '
+                    'latest version is %s==%s' % (
+                        name,
+                        req.comes_from,
+                        name,
+                        dist['latest_version']
+                    ))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
         url='https://github.com/di/pytest-reqs',
         py_modules=['pytest_reqs'],
         entry_points={'pytest11': ['reqs = pytest_reqs']},
-        install_requires=['pytest>=2.4.2', 'packaging>=17.1', 'pip_api>=0.0.2'],
+        install_requires=['pytest>=2.4.2', 'packaging>=17.1', 'pip-api>=0.0.2'],
         tests_require=['pytest>=2.4.2', 'pretend'],
         classifiers=[
             'Framework :: Pytest',

--- a/test_reqs.py
+++ b/test_reqs.py
@@ -80,9 +80,7 @@ def test_invalid_requirement(requirements, mock_dist, testdir, monkeypatch):
     result = testdir.runpytest("--reqs")
     result.stdout.fnmatch_lines([
         '*Invalid requirement*',
-        "*1 failed*",
     ])
-
     assert 'passed' not in result.stdout.str()
 
 
@@ -103,7 +101,7 @@ def test_local_requirement_ignored(testdir, monkeypatch):
     monkeypatch.setattr('pytest_reqs.pip_api.installed_distributions', lambda: {})
 
     result = testdir.runpytest("--reqs")
-    assert 'passed' in result.stdout.str()
+    assert 'collected 0 items' in result.stdout.str()
 
 
 def test_local_requirement_ignored_using_dynamic_config(testdir, monkeypatch):
@@ -115,7 +113,7 @@ def test_local_requirement_ignored_using_dynamic_config(testdir, monkeypatch):
     monkeypatch.setattr('pytest_reqs.pip_api.installed_distributions', lambda: {})
 
     result = testdir.runpytest("--reqs")
-    assert 'passed' in result.stdout.str()
+    assert 'collected 0 items' in result.stdout.str()
 
 
 def test_non_lowered_requirement(mock_dist, testdir, monkeypatch):
@@ -189,7 +187,7 @@ def test_outdated_version(requirements, testdir, monkeypatch):
 
     result = testdir.runpytest("--reqs-outdated")
     result.stdout.fnmatch_lines([
-        '*Distribution "foo" is outdated (from -r requirements.txt (line 1)), '
+        '*Distribution "foo" is outdated (from -r *requirements.txt (line 1)), '
         'latest version is foo==1.0.1*',
         "*1 failed*",
     ])


### PR DESCRIPTION
Instead of having a single entry per requirements file,
load it as a file with items for each entry in the file.

This allows errors for each problem, rather than only the
first problem with the requirements, and provides an
equivalent of `pip show` when pytest verbosity is increased.