### PR TITLE
Ignore pip VCS requirements

### DIFF
--- a/test_reqs.py
+++ b/test_reqs.py
@@ -115,6 +115,15 @@ def test_local_requirement_ignored(testdir, monkeypatch):
     assert "passed" in result.stdout.str()
 
 
+def test_vcs_requirement_ignored(testdir, monkeypatch):
+    testdir.makefile(".txt", requirements="git+https://github.com/foo/bar")
+    testdir.makeini("[pytest]\nreqsignorevcs=True")
+    monkeypatch.setattr("pytest_reqs.pip_api.installed_distributions", lambda: {})
+
+    result = testdir.runpytest("--reqs")
+    assert "passed" in result.stdout.str()
+
+
 def test_local_requirement_ignored_using_dynamic_config(testdir, monkeypatch):
     testdir.makefile(".txt", requirements="-e ../foo")
     testdir.makeconftest(


### PR DESCRIPTION
There are many limitations to checking VCS requirements.
Allow them to be ignored, similar to local requirements.

Related to https://github.com/di/pytest-reqs/issues/25