### PR TITLE
Skip unnecessary requirements

### DIFF
--- a/pytest_reqs.py
+++ b/pytest_reqs.py
@@ -141,6 +141,10 @@ class ReqsItem(pytest.Item, pytest.File):
 
     def runtest(self):
         for name, req in self.get_requirements().items():
+            if req.marker:
+                if not req.marker.evaluate():
+                    continue
+
             try:
                 installed_distribution = self.installed_distributions[name]
             except KeyError:

--- a/test_reqs.py
+++ b/test_reqs.py
@@ -1,3 +1,5 @@
+import sys
+
 from distutils.version import LooseVersion
 from pkg_resources import get_distribution
 
@@ -24,6 +26,8 @@ def mock_dist():
     'foo>=1.0',
     'foo<=1.0',
     '# comment',
+    'foo<=1.0;python_version>="1.0"',
+    'foo<=1.0;python_version<="%s"' % sys.version[:3],
 ])
 def test_existing_requirement(requirements, mock_dist, testdir, monkeypatch):
     testdir.makefile('.txt', requirements=requirements)
@@ -60,6 +64,15 @@ def test_canonicalization(requirements, dist, testdir, monkeypatch):
     assert 'passed' in result.stdout.str()
 
 
+def test_unnecessary_requirement(mock_dist, testdir, monkeypatch):
+    testdir.makefile('.txt',
+                     requirements='foo;python_version<"%s"' % sys.version[:3])
+    monkeypatch.setattr('pytest_reqs.pip_api.installed_distributions', lambda: {})
+
+    result = testdir.runpytest("--reqs")
+    assert 'passed' in result.stdout.str()
+
+
 def test_missing_requirement(mock_dist, testdir, monkeypatch):
     testdir.makefile('.txt', requirements='foo')
     monkeypatch.setattr('pytest_reqs.pip_api.installed_distributions', lambda: {})
@@ -76,6 +89,7 @@ def test_missing_requirement(mock_dist, testdir, monkeypatch):
     'foo==2.0',
     'foo>1.0',
     'foo<1.0',
+    'foo==2.0;python_version=="%s"' % sys.version[:3],
 ])
 def test_wrong_version(requirements, mock_dist, testdir, monkeypatch):
     testdir.makefile('.txt', requirements=requirements)
@@ -84,9 +98,10 @@ def test_wrong_version(requirements, mock_dist, testdir, monkeypatch):
         lambda: {mock_dist.project_name: mock_dist}
     )
 
+    name = requirements.split(';', 1)
     result = testdir.runpytest("--reqs")
     result.stdout.fnmatch_lines([
-        '*Distribution "foo" requires %s*' % (requirements),
+        '*Distribution "foo" requires %s*' % name,
         "*1 failed*",
     ])
     assert 'passed' not in result.stdout.str()
@@ -95,6 +110,7 @@ def test_wrong_version(requirements, mock_dist, testdir, monkeypatch):
 @pytest.mark.parametrize('requirements', [
     'foo=1.0',
     'foo=>1.0',
+    'foo==2.0; python_version=="%s"' % sys.version[:3],
 ])
 def test_invalid_requirement(requirements, mock_dist, testdir, monkeypatch):
     testdir.makefile('.txt', requirements=requirements)


### PR DESCRIPTION
Requirement markers should be evaluated, and
requirements discarded when they are not applicable
to the users environment.

Fixes https://github.com/di/pytest-reqs/issues/16